### PR TITLE
Support lager 2.0 data format

### DIFF
--- a/test/simple.erl
+++ b/test/simple.erl
@@ -12,4 +12,18 @@ aaa_test() ->
     ok = gen_event:stop(?MODULE),
     ok.
 
+lager_test() ->
+    {ok,Pid}=gen_event:start({local, ?MODULE}),
+    ok = gen_event:add_handler(?MODULE, fluent_event, debug),
+    ok = gen_event:notify(?MODULE, {<<"log">>, {lager_msg,
+                                                [],
+                                                [],
+                                                error,
+                                                {["2013",45,"08",45,"16"],["13",58,"41",58,"38",46,"275"]},
+                                                {1376,628098,275271},
+                                                ["\"a\""]}}),
+
+    ok = gen_event:stop(?MODULE),
+    ok.
+
 -endif.


### PR DESCRIPTION
Now, fluent-logger-erlang supports only lager 1.2.2 or lower style data format.
This pull request adds lager 2.0 style data format support.
